### PR TITLE
Trim whitespace from app id’s in editor

### DIFF
--- a/Facebook.Unity.Editor/FacebookSettingsEditor.cs
+++ b/Facebook.Unity.Editor/FacebookSettingsEditor.cs
@@ -181,7 +181,7 @@ namespace Facebook.Unity.Editor
                 GUI.changed = false;
                 EditorGUILayout.BeginHorizontal();
                 EditorGUILayout.LabelField(this.appIdLabel);
-                FacebookSettings.AppIds[i] = EditorGUILayout.TextField(FacebookSettings.AppIds[i]);
+                FacebookSettings.AppIds[i] = EditorGUILayout.TextField(FacebookSettings.AppIds[i]).Trim();
                 EditorGUILayout.EndHorizontal();
 
                 EditorGUILayout.BeginHorizontal();


### PR DESCRIPTION
Adding a space to the FB app id leads to build errors, as the app id is added to the manifest.