### PR TITLE
Optimization - avoid deserializing the graph result twice

### DIFF
--- a/Facebook.Unity/Results/GraphResult.cs
+++ b/Facebook.Unity/Results/GraphResult.cs
@@ -50,19 +50,16 @@ namespace Facebook.Unity
                 return;
             }
 
-            object serailizedResult = MiniJSON.Json.Deserialize(this.RawResult);
-            var jsonObject = serailizedResult as IDictionary<string, object>;
-            if (jsonObject != null)
+            if (this.ResultDictionary == null)
             {
-                this.ResultDictionary = jsonObject;
-                return;
-            }
+                object serailizedResult = MiniJSON.Json.Deserialize(this.RawResult);
 
-            var jsonArray = serailizedResult as IList<object>;
-            if (jsonArray != null)
-            {
-                this.ResultList = jsonArray;
-                return;
+                var jsonArray = serailizedResult as IList<object>;
+                if (jsonArray != null)
+                {
+                    this.ResultList = jsonArray;
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
The GraphResult constructor already initializes the ResultDictionary (from the underlying ResultContainer dictionary)
There’s no need to deserialize the data again and assign it, in case it was already done. This saves both execution time and unneeded GC.