### PR TITLE
Use UnityEngine.JsonUtility.ToJson(value) instead of SerializeString(value.ToString()) to serialize 'other' values.

### DIFF
--- a/Facebook.Unity/Utils/MiniJson.cs
+++ b/Facebook.Unity/Utils/MiniJson.cs
@@ -615,7 +615,7 @@ namespace Facebook.MiniJSON
                 }
                 else
                 {
-                    this.SerializeString(value.ToString());
+                    this.builder.Append(UnityEngine.JsonUtility.ToJson(value));
                 }
             }
         }


### PR DESCRIPTION
Improved MiniJson.Json.Serialize to utilize UnityEngine.JsonUtility.ToJson() to serialize System.Serializable classes/structs, rather than serializing the string of the object's ToString().  This allows for much more robust serialization.  For example you can do this:

```
[System.Serializable]
public struct MyData {
   public string id;
   public long timestamp;
   public string message;
}

MyData[] data = GetSomeData();
Json.Serialize(data);  
```
outputs: [{"id":"...","timestamp":1234,"message":"..."},{"id":"...","timestamp":1234,"message":"..."}]
instead of: ["MyData","MyData"]