### PR TITLE
Lower severity on editor warning

### DIFF
--- a/Facebook.Unity/PlatformEditor/EditorFacebook.cs
+++ b/Facebook.Unity/PlatformEditor/EditorFacebook.cs
@@ -75,7 +75,7 @@ namespace Facebook.Unity.Editor
         public override void Init(InitDelegate onInitComplete)
         {
             // Warn that editor behavior will not match supported platforms
-            FacebookLogger.Warn(WarningMessage);
+            FacebookLogger.Info(WarningMessage);
 
             base.Init(onInitComplete);
             this.editorWrapper.Init();


### PR DESCRIPTION
This message is not that critical to development, and results in a warning message while developing.  This results in having to relax constraints on CI and conditions developers to ignore warnings.