### PR TITLE
Remove warning when updating Android support libraries in Unity

### DIFF
--- a/Facebook.Unity.Editor/android/AndroidSupportLibraryResolver.cs
+++ b/Facebook.Unity.Editor/android/AndroidSupportLibraryResolver.cs
@@ -104,7 +104,6 @@ namespace Facebook.Unity.Editor
             String packageName,
             String version)
         {
-            Debug.LogWarning("App - " + packageName + ":" + version);
             Google.VersionHandler.InvokeInstanceMethod(
                 svcSupport,
                 "DependOn",


### PR DESCRIPTION
Before, when you would compile your Unity project with the Facebook SDK inside, it would print a few warnings to the log, which was cluttering the log.