### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.mdown
+++ b/CONTRIBUTING.mdown
@@ -1,5 +1,7 @@
 Facebook welcomes contributions to our SDKs.
 
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
+
 All contributors must sign a CLA (contributor license agreement) here:
 
   https://developers.facebook.com/opensource/cla


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

why make this change?:
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [Facebook SDK for Unity community profile
checklist](https://github.com/facebook/facebook-sdk-for-unity/community) and increase the visibility of our COC.

test plan:
Viewing it on my branch -
<img width="1032" alt="screen shot 2017-12-16 at 7 14 02 pm" src="https://user-images.githubusercontent.com/1114467/34076280-8ae803d2-e295-11e7-97ab-3b760168bda3.png">
<img width="1017" alt="screen shot 2017-12-16 at 7 14 23 pm" src="https://user-images.githubusercontent.com/1114467/34076281-8b03ae34-e295-11e7-80e1-ab80960d71e2.png">

issue:
internal task t23481323