### PR TITLE
Fix Login Callback

### DIFF
--- a/facebook-android-wrapper/src/com/facebook/unity/FBUnityLoginActivity.java
+++ b/facebook-android-wrapper/src/com/facebook/unity/FBUnityLoginActivity.java
@@ -21,6 +21,7 @@
 package com.facebook.unity;
 
 import com.facebook.CallbackManager;
+import com.facebook.FacebookSdk;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -29,6 +30,8 @@ import android.os.Bundle;
 public class FBUnityLoginActivity extends BaseActivity {
     public static final String LOGIN_PARAMS = "login_params";
     public static final String LOGIN_TYPE = "login_type";
+
+    private boolean didReceiveActivityResult = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,4 +65,20 @@ public class FBUnityLoginActivity extends BaseActivity {
         TV_PUBLISH
     }
 
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        didReceiveActivityResult = true;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if(!didReceiveActivityResult)
+        {
+            didReceiveActivityResult = true;
+            int loginRequestCode = FacebookSdk.getCallbackRequestCodeOffset();
+            mCallbackManager.onActivityResult(loginRequestCode, RESULT_CANCELED, null);
+        }
+    }
 }


### PR DESCRIPTION
This will fix the login callback not being called on Android if the player backgrounds the app with the login screen visible, and resumes the app from the app launcher (not the recent apps).