### PR TITLE
Fix `Constants` being inaccessible when the assembly files feature is used

### DIFF
--- a/Facebook.Unity/Constants.cs
+++ b/Facebook.Unity/Constants.cs
@@ -24,7 +24,7 @@ namespace Facebook.Unity
     using System.Globalization;
     using UnityEngine;
 
-    internal static class Constants
+    public static class Constants
     {
         // Callback keys
         public const string CallbackIdKey = "callback_id";


### PR DESCRIPTION
User-visible classes can't be `internal` anymore, since Unity 2017.3.

https://github.com/facebook/facebook-sdk-for-unity/issues/150