### PR TITLE
Fix SetAutoLogAppEventsEnabled for Android

### DIFF
--- a/Facebook.Unity/Mobile/Android/AndroidFacebook.cs
+++ b/Facebook.Unity/Mobile/Android/AndroidFacebook.cs
@@ -63,7 +63,7 @@ namespace Facebook.Unity.Mobile.Android
 
         public override void SetAutoLogAppEventsEnabled(bool autoLogAppEventsEnabled)
         {
-            this.CallFB("setAutoLogAppEventsEnabled", autoLogAppEventsEnabled.ToString());
+            this.CallFB("SetAutoLogAppEventsEnabled", autoLogAppEventsEnabled.ToString());
         }
 
         public override string SDKName

--- a/facebook-android-wrapper/src/com/facebook/unity/FB.java
+++ b/facebook-android-wrapper/src/com/facebook/unity/FB.java
@@ -214,6 +214,12 @@ public class FB {
     }
 
     @UnityCallable
+    public static void SetAutoLogAppEventsEnabled(String params_str) {
+        Log.v(TAG, "SetAutoLogAppEventsEnabled(" + params_str + ")");
+        FacebookSdk.setAutoLogAppEventsEnabled(Boolean.valueOf(params_str));
+    }
+
+    @UnityCallable
     public static void LogAppEvent(String params_str) {
         Log.v(TAG, "LogAppEvent(" + params_str + ")");
         UnityParams unity_params = UnityParams.parse(params_str);


### PR DESCRIPTION
Adds the missing 'SetAutoLogAppEventsEnabled' method to the android facebook wrapper.