### PR TITLE
- Fixed Mock Login copy-pasting issue

### DIFF
--- a/Facebook.Unity/PlatformEditor/MockDialogs/MockLoginDialog.cs
+++ b/Facebook.Unity/PlatformEditor/MockDialogs/MockLoginDialog.cs
@@ -40,7 +40,7 @@ namespace Facebook.Unity.Editor.Dialogs
         {
             GUILayout.BeginHorizontal();
             GUILayout.Label("User Access Token:");
-            this.accessToken = GUILayout.TextField(this.accessToken, GUI.skin.textArea, GUILayout.MinWidth(400));
+            this.accessToken = EditorGUI.TextField(this.accessToken, GUI.skin.textArea, GUILayout.MinWidth(400));
             GUILayout.EndHorizontal();
             GUILayout.Space(10);
             if (GUILayout.Button("Find Access Token"))


### PR DESCRIPTION
Using GUILayout for TextFields in Editor scripts disallows users from copy-pasting texts. This is a problem as this particular text field is used for an access token string, which becomes entirely cumbersome to type letter-by-letter.

This can be fixed by using EditorGUI or EditorGUILayout.TextField, which allows copy-pasting.