### PR TITLE
onOpenUrl compatible version

### DIFF
--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
@@ -84,10 +84,19 @@ static FBUnityInterface *_instance = [FBUnityInterface sharedInstance];
 - (void)onOpenURL:(NSNotification *)notification
 {
   NSURL *url = notification.userInfo[@"url"];
-  BOOL isHandledByFBSDK = [[FBSDKApplicationDelegate sharedInstance] application:[UIApplication sharedApplication]
-                                                                         openURL:url
-                                                               sourceApplication:notification.userInfo[@"sourceApplication"]
-                                                                      annotation:notification.userInfo[@"annotation"]];
+  BOOL isHandledByFBSDK = YES;
+  if ([UIDevice currentDevice].systemVersion.doubleValue >= 9.0) {
+    NSDictionary<UIApplicationOpenURLOptionsKey,id> *options = notification.userInfo[@"options"];
+    isHandledByFBSDK = [[FBSDKApplicationDelegate sharedInstance] application:[UIApplication sharedApplication]
+                                                                      openURL:url
+                                                            sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
+                                                                   annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+  } else {
+    isHandledByFBSDK = [[FBSDKApplicationDelegate sharedInstance] application:[UIApplication sharedApplication]
+                                                                      openURL:url
+                                                            sourceApplication:notification.userInfo[@"sourceApplication"]
+                                                                   annotation:notification.userInfo[@"annotation"]];
+  }
   if (!isHandledByFBSDK) {
     [FBUnityInterface sharedInstance].openURLString = [url absoluteString];
   }


### PR DESCRIPTION
we find that the API onOpenUrl does not work on the latest ios versions!
Actually, this should be merged after Unity add following code in UnityAppController.mm:
```Objective-C++
- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
    
    NSMutableArray* keys    = [NSMutableArray arrayWithCapacity: 2];
    NSMutableArray* values  = [NSMutableArray arrayWithCapacity: 2];
    
    #define ADD_ITEM(item)  do{ if(item) {[keys addObject:@#item]; [values addObject:item];} }while(0)
    
    ADD_ITEM(url);
    ADD_ITEM(options);
    
    #undef ADD_ITEM
    
    NSDictionary* notifData = [NSDictionary dictionaryWithObjects: values forKeys: keys];
    AppController_SendNotificationWithArg(kUnityOnOpenURL, notifData);
    return YES;
}
```