### PR TITLE
Remove unnecessary log

### DIFF
--- a/Facebook.Unity/PlatformEditor/EditorFacebook.cs
+++ b/Facebook.Unity/PlatformEditor/EditorFacebook.cs
@@ -28,9 +28,6 @@ namespace Facebook.Unity.Editor
 
     internal class EditorFacebook : FacebookBase, IMobileFacebookImplementation, ICanvasFacebookImplementation
     {
-        private const string WarningMessage = "You are using the facebook SDK in the Unity Editor. " +
-            "Behavior may not be the same as when used on iOS, Android, or Web.";
-
         private const string AccessTokenKey = "com.facebook.unity.editor.accesstoken";
 
         private IEditorWrapper editorWrapper;
@@ -74,9 +71,6 @@ namespace Facebook.Unity.Editor
 
         public override void Init(InitDelegate onInitComplete)
         {
-            // Warn that editor behavior will not match supported platforms
-            FacebookLogger.Warn(WarningMessage);
-
             base.Init(onInitComplete);
             this.editorWrapper.Init();
         }


### PR DESCRIPTION
This pull request removes the Warning "You are using the Facebook SDK in the Unity Editor. Behavior may not be the same as when used on iOS, Android, or Web."

This warning is shown every time we enter Play Mode in Unity with no options to disable it. As a consequence, other warnings that might be more important end up being less visible.

Please accept this pull request and move this message to a more appropriate place, such as the integration documentation.