### PR TITLE
Stop Facebook SDK from showing Debug.Log and Debug.LogWarning

### DIFF
--- a/Facebook.Unity/Utils/FacebookLogger.cs
+++ b/Facebook.Unity/Utils/FacebookLogger.cs
@@ -22,14 +22,14 @@ namespace Facebook.Unity
 {
     using UnityEngine;
 
-    internal static class FacebookLogger
+    public static class FacebookLogger
     {
         static FacebookLogger()
         {
             FacebookLogger.Instance = new DebugLogger();
         }
 
-        internal static IFacebookLogger Instance { private get; set; }
+        public static IFacebookLogger Instance { private get; set; }
 
         public static void Log(string msg)
         {

--- a/Facebook.Unity/Utils/IFacebookLogger.cs
+++ b/Facebook.Unity/Utils/IFacebookLogger.cs
@@ -20,7 +20,7 @@
 
 namespace Facebook.Unity
 {
-    internal interface IFacebookLogger
+    public interface IFacebookLogger
     {
         void Log(string msg);
 


### PR DESCRIPTION
### Issue
The Facebook SDK is known to produce a lot of Debug.Log/Debug.LogWarning during work.

For example: 
- Warning: "You are using the facebook SDK in the Unity Editor. " as in Pull request #223
- Log: "Pew! Pretending to send this off.  Doesn't actually work in the editor" whenever you call any FB SDK method.

Such warnings and logs are in most cases meaningless. In most projects, I want to keep Unity log clean for the really important stuff. Debug.Log is also pretty heavy operation as Unity needs to collect whole stack trace to display the message.

### Solution
Proposed solution make FacebookLogger public instead of internal so any developer who does not want to see FB log in Unity can implement IFacebookLogger based on his wish.

### Benefits
It does not change the standard logging behavior of Facebook SDK, while it gives a possibility for the developer to decide what to display and where.

### Usage
1. Define custom logger
```
    public class SilentLogger : IFacebookLogger
    {
        public void Log(string msg) {}
        public void Info(string msg) {}
        public void Warn(string msg) {}
        public void Error(string msg) {}
    }
```
2. Set the logger to the Facebook logger
```
FacebookLogger.Instance = new SilentLogger();
```