### PR TITLE
CanvasJSSDKBindings bug fix to allow Unity project development build to succeed

### DIFF
--- a/Facebook.Unity.Canvas/Plugins/CanvasJSSDKBindings.jslib
+++ b/Facebook.Unity.Canvas/Plugins/CanvasJSSDKBindings.jslib
@@ -272,5 +272,5 @@ var FBUnityLib = {
     }
 };
 
-autoAddDeps(LibraryManager.library, '$FBUnity');
+autoAddDeps(FBUnityLib, '$FBUnity');
 mergeInto(LibraryManager.library, FBUnityLib);


### PR DESCRIPTION
The original line translates to 

`Module["FBUnity"] = LibraryManager.library.$FBUnity`

Which is apparently wrong. $FBUnity is a member of FBUnityLib. It should be

`Module["FBUnity"] = FBUnityLib.$FBUnity`

That is, the first parameter for autoAddDeps should be `FBUnityLib`. Function autoAddDeps is defined in DynamicJslibLoader.js found under Unity's WebGL playback engine.

Without the fix, a development build for a Unity project with this library will fail with "Unresolved symbol: rand". Release build does work. I'm not sure why.