### PR TITLE
Add support for Custom Domains

### DIFF
--- a/Facebook.Unity.Tests/Login.cs
+++ b/Facebook.Unity.Tests/Login.cs
@@ -93,7 +93,8 @@ namespace Facebook.Unity.Tests
                 "1",
                 DateTime.UtcNow.AddDays(1),
                 new List<string>(), 
-                null);
+                null,
+                "facebook");
             Assert.IsTrue(FB.IsLoggedIn);
         }
 
@@ -105,7 +106,8 @@ namespace Facebook.Unity.Tests
                 "1",
                 DateTime.UtcNow.AddDays(-1),
                 new List<string>(), 
-                null);
+                null,
+                "facebook");
             Assert.IsFalse(FB.IsLoggedIn);
         }
 

--- a/Facebook.Unity/AccessToken.cs
+++ b/Facebook.Unity/AccessToken.cs
@@ -42,7 +42,8 @@ namespace Facebook.Unity
             string userId,
             DateTime expirationTime,
             IEnumerable<string> permissions,
-            DateTime? lastRefresh)
+            DateTime? lastRefresh,
+            string graphDomain)
         {
             if (string.IsNullOrEmpty(tokenString))
             {
@@ -69,6 +70,7 @@ namespace Facebook.Unity
             this.Permissions = permissions;
             this.UserId = userId;
             this.LastRefresh = lastRefresh;
+            this.GraphDomain = graphDomain;
         }
 
         /// <summary>
@@ -107,6 +109,12 @@ namespace Facebook.Unity
         /// <value>The last refresh.</value>
         public DateTime? LastRefresh { get; private set; }
 
+
+        /// <summary>
+        /// Gets the domain this access token is valid for.
+        /// </summary>
+        public String GraphDomain { get; private set; }
+
         /// <summary>
         /// Returns a <see cref="System.String"/> that represents the current <see cref="Facebook.Unity.AccessToken"/>.
         /// </summary>
@@ -122,6 +130,7 @@ namespace Facebook.Unity
                     { "Permissions", this.Permissions.ToCommaSeparateList() },
                     { "UserId", this.UserId.ToStringNullOk() },
                     { "LastRefresh", this.LastRefresh.ToStringNullOk() },
+                    { "GraphDomain", this.GraphDomain },
                 });
         }
 
@@ -136,6 +145,8 @@ namespace Facebook.Unity
             {
                 dictionary[LoginResult.LastRefreshKey] = this.LastRefresh.Value.TotalSeconds().ToString();
             }
+            dictionary[LoginResult.GraphDomain] = this.GraphDomain;
+            
 
             return MiniJSON.Json.Serialize(dictionary);
         }

--- a/Facebook.Unity/PlatformEditor/MockDialogs/MockLoginDialog.cs
+++ b/Facebook.Unity/PlatformEditor/MockDialogs/MockLoginDialog.cs
@@ -107,7 +107,8 @@ namespace Facebook.Unity.Editor.Dialogs
                         facebookID,
                         DateTime.UtcNow.AddDays(60),
                         grantedPerms,
-                        DateTime.UtcNow);
+                        DateTime.UtcNow,
+                        "facebook");
 
                     var result = (IDictionary<string, object>)MiniJSON.Json.Deserialize(newToken.ToJson());
                     result.Add("granted_permissions", grantedPerms);

--- a/Facebook.Unity/Results/LoginResult.cs
+++ b/Facebook.Unity/Results/LoginResult.cs
@@ -29,6 +29,7 @@ namespace Facebook.Unity
         public static readonly string ExpirationTimestampKey = Constants.IsWeb ? "expiresIn" : "expiration_timestamp";
         public static readonly string PermissionsKey = Constants.IsWeb ? "grantedScopes" : "permissions";
         public static readonly string AccessTokenKey = Constants.IsWeb ? "accessToken" : Constants.AccessTokenKey;
+        public static readonly string GraphDomain = "graph_domain";
 
         internal LoginResult(ResultContainer resultContainer) : base(resultContainer)
         {

--- a/Facebook.Unity/Utils/Utilities.cs
+++ b/Facebook.Unity/Utils/Utilities.cs
@@ -144,13 +144,15 @@ namespace Facebook.Unity
             DateTime expiration = Utilities.ParseExpirationDateFromResult(resultDictionary);
             ICollection<string> permissions = Utilities.ParsePermissionFromResult(resultDictionary);
             DateTime? lastRefresh = Utilities.ParseLastRefreshFromResult(resultDictionary);
+            string graphDomain = resultDictionary.GetValueOrDefault<string>(LoginResult.GraphDomain);
 
             return new AccessToken(
                 accessToken,
                 userID,
                 expiration,
                 permissions,
-                lastRefresh);
+                lastRefresh,
+                graphDomain);
         }
 
         public static string ToStringNullOk(this object obj)


### PR DESCRIPTION
Summary: Certain AccessTokens are only valid for a specific domain. This change allows the AcessToken class to track the domain it is valid for.

Reviewed By: KylinChang

Differential Revision: D20039967

