### PR TITLE
Use correct GraphDomain for GraphAPI requests

### DIFF
--- a/Facebook.Unity/FB.cs
+++ b/Facebook.Unity/FB.cs
@@ -41,6 +41,7 @@ namespace Facebook.Unity
         private static IFacebook facebook;
         private static bool isInitCalled = false;
         private static string facebookDomain = "facebook.com";
+        private static string gamingDomain = "fb.gg";
         private static string graphApiVersion = Constants.GraphApiVersion;
 
         private delegate void OnDLLLoaded();
@@ -156,6 +157,12 @@ namespace Facebook.Unity
         {
             get
             {
+                if (FB.IsLoggedIn || AccessToken.CurrentAccessToken.GraphDomain != null) {
+                    string graphDomain = AccessToken.CurrentAccessToken.GraphDomain;
+                    if (graphDomain == "gaming") {
+                        return FB.gamingDomain;
+                    }
+                } 
                 return FB.facebookDomain;
             }
 


### PR DESCRIPTION
Summary: if the domain is 'gaming' for an AccessToken, then all the requests need to go to graph.fb.gg.  This change makes that happen.

Reviewed By: KylinChang

Differential Revision: D20040265

