### PR TITLE
Add GamingImageUploader support on iOS

### DIFF
--- a/Facebook.Unity.IOS/IOSWrapper.cs
+++ b/Facebook.Unity.IOS/IOSWrapper.cs
@@ -223,6 +223,19 @@ namespace Facebook.Unity.IOS
             IOSWrapper.IOSFBUpdateUserProperties(numParams, paramKeys, paramVals);
         }
 
+        public void UploadImageToMediaLibrary(
+            int requestId,
+            string caption,
+            string imageUri,
+            bool shouldLaunchMediaDialog)
+        {
+            IOSWrapper.IOSFBUploadImageToMediaLibrary(
+                requestId,
+                caption,
+                imageUri,
+                shouldLaunchMediaDialog);
+        }
+
         public void FetchDeferredAppLink(int requestId)
         {
             IOSWrapper.IOSFBFetchDeferredAppLink(requestId);
@@ -339,6 +352,13 @@ namespace Facebook.Unity.IOS
 
         [DllImport("__Internal")]
         private static extern void IOSFBOpenGamingServicesFriendFinder(int requestID);
+
+        [DllImport("__Internal")]
+        private static extern void IOSFBUploadImageToMediaLibrary(
+            int requestID,
+            string caption,
+            string imageUri,
+            bool shouldLaunchMediaDialog);
 
         [DllImport("__Internal")]
         private static extern string IOSFBGetUserID();

--- a/Facebook.Unity.Tests/Mobile/IOS/MockIOS.cs
+++ b/Facebook.Unity.Tests/Mobile/IOS/MockIOS.cs
@@ -229,5 +229,15 @@ namespace Facebook.Unity.Tests.Mobile.IOS
         {
             this.LogMethodCall();
         }
+
+        public void UploadImageToMediaLibrary(
+            int requestId,
+            string caption,
+            string mediaUri,
+            bool shouldLaunchMediaDialog)
+        {
+            var result = MockResults.GetGenericResult(requestId, this.ResultExtras);
+            this.MobileFacebook.OnUploadImageToMediaLibraryComplete(new ResultContainer(result));
+        }
     }
 }

--- a/Facebook.Unity/Mobile/IOS/IIOSWrapper.cs
+++ b/Facebook.Unity/Mobile/IOS/IIOSWrapper.cs
@@ -115,6 +115,12 @@ namespace Facebook.Unity.Mobile.IOS
             string[] paramKeys,
             string[] paramVals);
 
+        void UploadImageToMediaLibrary(
+            int requestId,
+            string caption,
+            string mediaUri,
+            bool shouldLaunchMediaDialog);
+
         void FetchDeferredAppLink(int requestId);
     }
 }

--- a/Facebook.Unity/Mobile/IOS/IOSFacebook.cs
+++ b/Facebook.Unity/Mobile/IOS/IOSFacebook.cs
@@ -306,6 +306,19 @@ namespace Facebook.Unity.Mobile.IOS
             this.iosWrapper.SetShareDialogMode((int)mode);
         }
 
+        public override void UploadImageToMediaLibrary(
+            string caption,
+            Uri imageUri,
+            bool shouldLaunchMediaDialog,
+            FacebookDelegate<IMediaUploadResult> callback)
+        {
+            this.iosWrapper.UploadImageToMediaLibrary(
+                System.Convert.ToInt32(CallbackManager.AddFacebookDelegate(callback)),
+                caption,
+                imageUri.AbsolutePath.ToString(),
+                shouldLaunchMediaDialog);
+        }
+
         private static IIOSWrapper GetIOSWrapper()
         {
             Assembly assembly = Assembly.Load("Facebook.Unity.IOS");

--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
@@ -505,6 +505,37 @@ extern "C" {
       }];
   }
 
+  void IOSFBUploadImageToMediaLibrary(int requestId,
+                                      const char *caption,
+                                      const char *imageUri,
+                                      bool shouldLaunchMediaDialog)
+  {
+    NSString *captionString = [FBUnityUtility stringFromCString:caption];
+    NSString *imageUriString = [FBUnityUtility stringFromCString:imageUri];
+    UIImage *image = [UIImage imageWithContentsOfFile:imageUriString];
+
+    FBSDKGamingImageUploaderConfiguration *config =
+    [[FBSDKGamingImageUploaderConfiguration alloc]
+      initWithImage:image
+      caption:captionString
+      shouldLaunchMediaDialog:shouldLaunchMediaDialog ? YES: NO];
+
+    [FBSDKGamingImageUploader
+      uploadImageWithConfiguration:config
+      andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+        if (!success || error) {
+          [FBUnityUtility sendErrorToUnity:FBUnityMessageName_OnUploadImageToMediaLibraryComplete
+            error:error
+            requestId:requestId];
+        } else {
+          [FBUnityUtility sendMessageToUnity:FBUnityMessageName_OnUploadImageToMediaLibraryComplete
+            userData:NULL
+            requestId:requestId];
+        }
+    }];
+
+  }
+
   char* IOSFBGetUserID()
   {
     NSString *userID = [FBSDKAppEvents userID];

--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnitySDKDelegate.h
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnitySDKDelegate.h
@@ -29,6 +29,7 @@ extern NSString *const FBUnityMessageName_OnLogoutComplete;
 extern NSString *const FBUnityMessageName_OnShareLinkComplete;
 extern NSString *const FBUnityMessageName_OnFetchDeferredAppLinkComplete;
 extern NSString *const FBUnityMessageName_OnRefreshCurrentAccessTokenComplete;
+extern NSString *const FBUnityMessageName_OnUploadImageToMediaLibraryComplete;
 
 /*!
  @abstract A helper class that implements various FBSDK delegates in order to send

--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnitySDKDelegate.m
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnitySDKDelegate.m
@@ -31,6 +31,7 @@ NSString *const FBUnityMessageName_OnLogoutComplete = @"OnLogoutComplete";
 NSString *const FBUnityMessageName_OnShareLinkComplete = @"OnShareLinkComplete";
 NSString *const FBUnityMessageName_OnFetchDeferredAppLinkComplete = @"OnFetchDeferredAppLinkComplete";
 NSString *const FBUnityMessageName_OnRefreshCurrentAccessTokenComplete = @"OnRefreshCurrentAccessTokenComplete";
+NSString *const FBUnityMessageName_OnUploadImageToMediaLibraryComplete = @"OnUploadImageToMediaLibraryComplete";
 
 static NSMutableArray *g_instances;
 


### PR DESCRIPTION
Summary: This allows iOS to use FBGamingServices.UploadImageToMediaLibrary().

Reviewed By: dloomb, KylinChang

Differential Revision: D20351560

