### PR TITLE
Add Gaming Video Upload Support for iOS

### DIFF
--- a/Facebook.Unity.IOS/IOSWrapper.cs
+++ b/Facebook.Unity.IOS/IOSWrapper.cs
@@ -236,6 +236,17 @@ namespace Facebook.Unity.IOS
                 shouldLaunchMediaDialog);
         }
 
+        public void UploadVideoToMediaLibrary(
+            int requestId,
+            string caption,
+            string videoUri)
+        {
+            IOSWrapper.IOSFBUploadVideoToMediaLibrary(
+                requestId,
+                caption,
+                videoUri);
+        }
+
         public void FetchDeferredAppLink(int requestId)
         {
             IOSWrapper.IOSFBFetchDeferredAppLink(requestId);
@@ -359,6 +370,12 @@ namespace Facebook.Unity.IOS
             string caption,
             string imageUri,
             bool shouldLaunchMediaDialog);
+
+        [DllImport("__Internal")]
+        private static extern void IOSFBUploadVideoToMediaLibrary(
+            int requestID,
+            string caption,
+            string videoUri);
 
         [DllImport("__Internal")]
         private static extern string IOSFBGetUserID();

--- a/Facebook.Unity.Tests/Mobile/IOS/MockIOS.cs
+++ b/Facebook.Unity.Tests/Mobile/IOS/MockIOS.cs
@@ -239,5 +239,14 @@ namespace Facebook.Unity.Tests.Mobile.IOS
             var result = MockResults.GetGenericResult(requestId, this.ResultExtras);
             this.MobileFacebook.OnUploadImageToMediaLibraryComplete(new ResultContainer(result));
         }
+
+        public void UploadVideoToMediaLibrary(
+            int requestId,
+            string caption,
+            string mediaUri)
+        {
+            var result = MockResults.GetGenericResult(requestId, this.ResultExtras);
+            this.MobileFacebook.OnUploadVideoToMediaLibraryComplete(new ResultContainer(result));
+        }
     }
 }

--- a/Facebook.Unity/Mobile/IOS/IIOSWrapper.cs
+++ b/Facebook.Unity/Mobile/IOS/IIOSWrapper.cs
@@ -121,6 +121,11 @@ namespace Facebook.Unity.Mobile.IOS
             string mediaUri,
             bool shouldLaunchMediaDialog);
 
+        void UploadVideoToMediaLibrary(
+            int requestId,
+            string caption,
+            string videoUri);
+
         void FetchDeferredAppLink(int requestId);
     }
 }

--- a/Facebook.Unity/Mobile/IOS/IOSFacebook.cs
+++ b/Facebook.Unity/Mobile/IOS/IOSFacebook.cs
@@ -319,6 +319,17 @@ namespace Facebook.Unity.Mobile.IOS
                 shouldLaunchMediaDialog);
         }
 
+        public override void UploadVideoToMediaLibrary(
+            string caption,
+            Uri videoUri,
+            FacebookDelegate<IMediaUploadResult> callback)
+        {
+            this.iosWrapper.UploadVideoToMediaLibrary(
+                System.Convert.ToInt32(CallbackManager.AddFacebookDelegate(callback)),
+                caption,
+                videoUri.AbsolutePath.ToString());
+        }
+
         private static IIOSWrapper GetIOSWrapper()
         {
             Assembly assembly = Assembly.Load("Facebook.Unity.IOS");

--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
@@ -536,6 +536,35 @@ extern "C" {
 
   }
 
+  void IOSFBUploadVideoToMediaLibrary(int requestId,
+                                      const char *caption,
+                                      const char *videoUri)
+  {
+    NSString *captionString = [FBUnityUtility stringFromCString:caption];
+    NSString *videoUriString = [FBUnityUtility stringFromCString:videoUri];
+    NSURL *videoURL = [NSURL fileURLWithPath:videoUriString];
+
+    FBSDKGamingVideoUploaderConfiguration *config =
+    [[FBSDKGamingVideoUploaderConfiguration alloc]
+      initWithVideoURL:videoURL
+      caption:captionString];
+
+    [FBSDKGamingVideoUploader
+      uploadVideoWithConfiguration:config
+      andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+        if (!success || error) {
+          [FBUnityUtility sendErrorToUnity:FBUnityMessageName_OnUploadVideoToMediaLibraryComplete
+            error:error
+            requestId:requestId];
+        } else {
+          [FBUnityUtility sendMessageToUnity:FBUnityMessageName_OnUploadVideoToMediaLibraryComplete
+            userData:NULL
+            requestId:requestId];
+        }
+    }];
+
+  }
+
   char* IOSFBGetUserID()
   {
     NSString *userID = [FBSDKAppEvents userID];

--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnitySDKDelegate.h
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnitySDKDelegate.h
@@ -30,6 +30,7 @@ extern NSString *const FBUnityMessageName_OnShareLinkComplete;
 extern NSString *const FBUnityMessageName_OnFetchDeferredAppLinkComplete;
 extern NSString *const FBUnityMessageName_OnRefreshCurrentAccessTokenComplete;
 extern NSString *const FBUnityMessageName_OnUploadImageToMediaLibraryComplete;
+extern NSString *const FBUnityMessageName_OnUploadVideoToMediaLibraryComplete;
 
 /*!
  @abstract A helper class that implements various FBSDK delegates in order to send

--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnitySDKDelegate.m
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnitySDKDelegate.m
@@ -32,6 +32,7 @@ NSString *const FBUnityMessageName_OnShareLinkComplete = @"OnShareLinkComplete";
 NSString *const FBUnityMessageName_OnFetchDeferredAppLinkComplete = @"OnFetchDeferredAppLinkComplete";
 NSString *const FBUnityMessageName_OnRefreshCurrentAccessTokenComplete = @"OnRefreshCurrentAccessTokenComplete";
 NSString *const FBUnityMessageName_OnUploadImageToMediaLibraryComplete = @"OnUploadImageToMediaLibraryComplete";
+NSString *const FBUnityMessageName_OnUploadVideoToMediaLibraryComplete = @"OnUploadVideoToMediaLibraryComplete";
 
 static NSMutableArray *g_instances;
 


### PR DESCRIPTION
Summary: Allows FBGamingServices.UploadVideoToMediaLibrary() to work on iOS.

Reviewed By: joeymrios

Differential Revision: D20376389

