### PR TITLE
Fix EditorFacebook Login bug

### DIFF
--- a/Facebook.Unity/FB.cs
+++ b/Facebook.Unity/FB.cs
@@ -157,7 +157,7 @@ namespace Facebook.Unity
         {
             get
             {
-                if (FB.IsLoggedIn || AccessToken.CurrentAccessToken.GraphDomain != null) {
+                if (FB.IsLoggedIn && AccessToken.CurrentAccessToken != null) {
                     string graphDomain = AccessToken.CurrentAccessToken.GraphDomain;
                     if (graphDomain == "gaming") {
                         return FB.gamingDomain;


### PR DESCRIPTION
Summary:
The custom domain work introduced a bug here that breaks Editor Facebook from working.

It was trying to query the Domain from the AccessToken when the Access Token was not constructed yet.

Reviewed By: joeymrios

Differential Revision: D20549978

