### PR TITLE
(iOS)token.graphDomain needs nil fix to prevent crash.

### DIFF
--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityUtility.mm
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityUtility.mm
@@ -205,7 +205,8 @@ static char* FBUnityMakeStringCopy (const char* string)
         token.expirationDate &&
         token.userID &&
         token.permissions &&
-        token.declinedPermissions) {
+        token.declinedPermissions &&
+        token.graphDomain) {
       NSInteger expiration = token.expirationDate.timeIntervalSince1970;
       NSInteger lastRefreshDate = token.refreshDate ? token.refreshDate.timeIntervalSince1970 : 0;
       return @{


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Related to issue #421. 
token.graphDomain lacks nil check. This will cause old sdk users to crash on FB.Init() call.

## Test Plan

Use sign in with facebook on FB SDK ver 7.13.0, then update sdk to recent(7.19.1) and check cached accessToken causes crash or not. 
