### PR TITLE
Fix crash when AccessToken has no graph domain

### DIFF
--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityUtility.mm
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityUtility.mm
@@ -217,7 +217,7 @@ static char* FBUnityMakeStringCopy (const char* string)
                @"granted_permissions" : [token.permissions allObjects],
                @"declined_permissions" : [token.declinedPermissions allObjects],
                @"last_refresh" : [@(lastRefreshDate) stringValue],
-               @"graph_domain" : token.graphDomain,
+               @"graph_domain" : token.graphDomain ? : @"facebook",
                };
     }
   }

--- a/facebook-android-wrapper/src/com/facebook/unity/FBLogin.java
+++ b/facebook-android-wrapper/src/com/facebook/unity/FBLogin.java
@@ -81,7 +81,7 @@ public class FBLogin {
                 TextUtils.join(",", token.getPermissions()));
         unityMessage.put("declined_permissions",
                 TextUtils.join(",", token.getDeclinedPermissions()));
-        unityMessage.put("graph_domain", token.getGraphDomain());
+        unityMessage.put("graph_domain", token.getGraphDomain() != null ? token.getGraphDomain() : "facebook");
 
         if (token.getLastRefresh() != null) {
             Long lastRefresh = token.getLastRefresh().getTime() / 1000;


### PR DESCRIPTION
Summary:
When upgrading the unity SDK to v7.19+ there is a crash if there is an existing access token since it doesn't know about its graph domain.

This fixes that by providing a fallback value.

Differential Revision: D20784206

