### PR TITLE
return media_id from iOS for GamingServices media uploads

### DIFF
--- a/UnitySDK/Assets/FacebookSDK/Plugins/Editor/Dependencies.xml
+++ b/UnitySDK/Assets/FacebookSDK/Plugins/Editor/Dependencies.xml
@@ -9,9 +9,9 @@
         <androidPackage spec="com.facebook.android:facebook-gamingservices:[6.2.0, 7)" />
     </androidPackages>
     <iosPods>
-        <iosPod name="FBSDKCoreKit" version="~> 6.2" />
-        <iosPod name="FBSDKLoginKit" version="~> 6.2" />
-        <iosPod name="FBSDKShareKit" version="~> 6.2" />
-        <iosPod name="FBSDKGamingServicesKit" version="~> 6.2" />
+        <iosPod name="FBSDKCoreKit" version="~> 6.5.2" />
+        <iosPod name="FBSDKLoginKit" version="~> 6.5.2" />
+        <iosPod name="FBSDKShareKit" version="~> 6.5.2" />
+        <iosPod name="FBSDKGamingServicesKit" version="~> 6.5.2" />
     </iosPods>
 </dependencies>

--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
@@ -522,14 +522,14 @@ extern "C" {
 
     [FBSDKGamingImageUploader
       uploadImageWithConfiguration:config
-      andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+      andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
         if (!success || error) {
           [FBUnityUtility sendErrorToUnity:FBUnityMessageName_OnUploadImageToMediaLibraryComplete
             error:error
             requestId:requestId];
         } else {
           [FBUnityUtility sendMessageToUnity:FBUnityMessageName_OnUploadImageToMediaLibraryComplete
-            userData:NULL
+            userData:@{@"id":result[@"id"]}
             requestId:requestId];
         }
     }];
@@ -551,14 +551,14 @@ extern "C" {
 
     [FBSDKGamingVideoUploader
       uploadVideoWithConfiguration:config
-      andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+      andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
         if (!success || error) {
           [FBUnityUtility sendErrorToUnity:FBUnityMessageName_OnUploadVideoToMediaLibraryComplete
             error:error
             requestId:requestId];
         } else {
           [FBUnityUtility sendMessageToUnity:FBUnityMessageName_OnUploadVideoToMediaLibraryComplete
-            userData:NULL
+            userData:@{@"id":result[@"id"]}
             requestId:requestId];
         }
     }];


### PR DESCRIPTION
Summary: Previously the iOS SDK didn't return the media id after uploading images/videos. Now that it does this wires the returned ID back to unity.

Reviewed By: dloomb

Differential Revision: D21605593

