### PR TITLE
Fix errors with custom Android keystores

### DIFF
--- a/Facebook.Unity.Editor/FacebookPostprocess.cs
+++ b/Facebook.Unity.Editor/FacebookPostprocess.cs
@@ -57,7 +57,7 @@ namespace Facebook.Unity.Editor
 
                 if (!FacebookAndroidUtil.SetupProperly)
                 {
-                    Debug.LogError("Your Android setup is not correct. See Settings in Facebook menu.");
+                    Debug.LogError("Your Android setup is not correct. " + FacebookAndroidUtil.SetupError);
                 }
 
                 if (!ManifestMod.CheckManifest())

--- a/Facebook.Unity.Editor/FacebookSettingsEditor.cs
+++ b/Facebook.Unity.Editor/FacebookSettingsEditor.cs
@@ -60,7 +60,7 @@ namespace Facebook.Unity.Editor
 
         private GUIContent packageNameLabel = new GUIContent("Package Name [?]", "aka: the bundle identifier");
         private GUIContent classNameLabel = new GUIContent("Class Name [?]", "aka: the activity name");
-        private GUIContent debugAndroidKeyLabel = new GUIContent("Debug Android Key Hash [?]", "Copy this key to the Facebook Settings in order to test a Facebook Android app");
+        private GUIContent androidKeyLabel = new GUIContent("Android Key Hash [?]", "Copy this key to the Facebook Settings in order to test a Facebook Android app");
 
         private GUIContent autoLogAppEventsLabel = new GUIContent("Auto Logging App Events [?]", "If true, automatically log app install, app launch and in-app purchase events to Facebook. https://developers.facebook.com/docs/app-events/");
         private GUIContent advertiserIDCollectionLabel = new GUIContent("AdvertiserID Collection [?]", "If true, attempts to collect user's AdvertiserID. https://developers.facebook.com/docs/app-ads/targeting/mobile-advertiser-ids/");
@@ -280,25 +280,9 @@ namespace Facebook.Unity.Editor
             {
                 if (!FacebookAndroidUtil.SetupProperly)
                 {
-                    var msg = "Your Android setup is not right. Check the documentation.";
-                    switch (FacebookAndroidUtil.SetupError)
-                    {
-                        case FacebookAndroidUtil.ErrorNoSDK:
-                            msg = "You don't have the Android SDK setup!  Go to " + (Application.platform == RuntimePlatform.OSXEditor ? "Unity" : "Edit") + "->Preferences... and set your Android SDK Location under External Tools";
-                            break;
-                        case FacebookAndroidUtil.ErrorNoKeystore:
-                            msg = "Your android debug keystore file is missing! You can create new one by creating and building empty Android project in Ecplise.";
-                            break;
-                        case FacebookAndroidUtil.ErrorNoKeytool:
-                            msg = "Keytool not found. Make sure that Java is installed, and that Java tools are in your path.";
-                            break;
-                        case FacebookAndroidUtil.ErrorNoOpenSSL:
-                            msg = "OpenSSL not found. Make sure that OpenSSL is installed, and that it is in your path.";
-                            break;
-                        case FacebookAndroidUtil.ErrorKeytoolError:
-                            msg = "Unkown error while getting Debug Android Key Hash.";
-                            break;
-                    }
+                    var msg = FacebookAndroidUtil.SetupError != null
+                        ? FacebookAndroidUtil.SetupError
+                        : "Your Android setup is not right. Check the documentation.";
 
                     EditorGUILayout.HelpBox(msg, MessageType.Warning);
                 }
@@ -307,7 +291,7 @@ namespace Facebook.Unity.Editor
                     "Copy and Paste these into your \"Native Android App\" Settings on developers.facebook.com/apps");
                 this.SelectableLabelField(this.packageNameLabel, Utility.GetApplicationIdentifier());
                 this.SelectableLabelField(this.classNameLabel, ManifestMod.DeepLinkingActivityName);
-                this.SelectableLabelField(this.debugAndroidKeyLabel, FacebookAndroidUtil.DebugKeyHash);
+                this.SelectableLabelField(this.androidKeyLabel, FacebookAndroidUtil.KeyHash);
                 if (GUILayout.Button("Regenerate Android Manifest"))
                 {
                     ManifestMod.GenerateManifest();


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details
We were getting the following errors when building:
```
Your Android setup is not correct. See Settings in Facebook menu.
```
This prevents us from building with [strict mode](https://docs.unity3d.com/ScriptReference/BuildOptions.StrictMode.html) enabled.

First off, this error wasn't informative when building from command line. I solved this by moving the error message logic to `FacebookAndroidUtil`. This eliminated the need for the magic error strings we had in that class.

After this, we knew that the error was that Facebook SDK couldn't find our Android keystore. As it turns out, the SDK was looking for the debug keystore created by Eclipse/Android Studio. This however did not exist because we were using a keystore set in Unity's Project Settings: 
<img width="530" alt="Screenshot 2020-07-03 at 17 48 36" src="https://user-images.githubusercontent.com/431167/86479763-7457c380-bd55-11ea-8a43-3ebfc69d989e.png">

This PR fixes the issue by adding support for such keystores. It also fixes the key hash that's displayed in Facebook Settings, which was only showing the hash for that debug keystore previously.

## Test Plan

Test custom keystore:
1. Delete `~/.android/debug.keystore` if exists
2. Select a keystore file in Project Settings -> Player -> Android -> Publishing settings
3. Open Facebook Settings and verify that the hash is displayed correctly

Test debug keystore:
1. Re-create `~/.android/debug.keystore`
2. Go to Project Settings -> Player -> Android -> Publishing settings and uncheck "Use Existing Keystore". Alternatively, you can also select "Unsigned (debug)" as the key alias:
<img width="503" alt="Screenshot 2020-07-03 at 17 54 53" src="https://user-images.githubusercontent.com/431167/86480268-576fc000-bd56-11ea-8c15-046e58e147bf.png">
3. Open Facebook Settings and verify that the hash is displayed correctly
