### PR TITLE
Fix iOS build with Unity 2019.3 and later

### DIFF
--- a/Facebook.Unity.Editor/iOS/FixupFiles.cs
+++ b/Facebook.Unity.Editor/iOS/FixupFiles.cs
@@ -53,7 +53,12 @@ namespace Facebook.Unity.Editor
             string projPath = Path.Combine(path, Path.Combine("Unity-iPhone.xcodeproj", "project.pbxproj"));
             PBXProject proj = new PBXProject();
             proj.ReadFromString(File.ReadAllText(projPath));
-            string targetGUID = proj.TargetGuidByName("Unity-iPhone");
+
+            // When building with Unity 2019.3 and later versions, there are two Xcode targets generated.
+            // The UnityFramework target will include the code and Unity-iPhone is only a thin wrapper around it.
+            // With earlier versions everything is in a single Unity-iPhone target.
+            var targetName = GetUnityVersionNumber() >= 201930 ? "UnityFramework" : "Unity-iPhone";
+            string targetGUID = proj.TargetGuidByName(targetName);
             proj.AddBuildProperty(targetGUID, "GCC_PREPROCESSOR_DEFINITIONS", " $(inherited) FBSDKCOCOAPODS=1");
             proj.AddBuildProperty(targetGUID, "OTHER_LDFLAGS", "-ObjC");
             proj.AddBuildProperty(targetGUID, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

I don't have the permission to add labels.

## Pull Request Details

The proposed fix only worked for older Unity versions. Resolves #450.

## Test Plan

Build for iOS using various Unity versions
