### PR TITLE
Fix double "use_frameworks!" declaration

### DIFF
--- a/Facebook.Unity.Editor/FacebookPostprocess.cs
+++ b/Facebook.Unity.Editor/FacebookPostprocess.cs
@@ -37,6 +37,7 @@ namespace Facebook.Unity.Editor
                 string podFilePath = Path.Combine(buildPath, "Podfile");
                 string contents = File.ReadAllText(podFilePath);
                 bool isUnityIphoneInPodFile = contents.Contains("Unity-iPhone");
+                bool isUseFrameworksInPodFile = contents.Contains("use_frameworks!");
                 using (StreamWriter sw = File.AppendText(podFilePath))
                 {
                     if (!isUnityIphoneInPodFile)
@@ -44,7 +45,11 @@ namespace Facebook.Unity.Editor
                         sw.WriteLine("target 'Unity-iPhone' do");
                         sw.WriteLine("end");
                     }
-                    sw.WriteLine("use_frameworks!");
+
+                    if (!isUseFrameworksInPodFile)
+                    {
+                        sw.WriteLine("use_frameworks!");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

This is mostly cosmetic fix. By default, the Postprocess script adds "use_frameworks!" to the end of the file without checking if it was in the file already. This results in two "use_frameworks!" declarations. The first one could be generated by another postprocess script or by the External Dependency Manager.

## Test Plan

Test Plan:
- Create and setup project for iOS
- Import and setup Facebook SDK
- Enable "Add use_frameworks! to Podfile" in iOS Resolver settings
- Build the project
- There should be only one "use_frameworks!" declaration