### PR TITLE
Fix 'no Android SDK' false positive error

### DIFF
--- a/Facebook.Unity.Editor/android/FacebookAndroidUtil.cs
+++ b/Facebook.Unity.Editor/android/FacebookAndroidUtil.cs
@@ -28,6 +28,7 @@ namespace Facebook.Unity.Editor
     using Facebook.Unity.Settings;
     using Google;
     using UnityEditor;
+    using UnityEditor.Android;
     using UnityEngine;
 
     public class FacebookAndroidUtil
@@ -121,7 +122,7 @@ namespace Facebook.Unity.Editor
 
         public static string GetAndroidSdkPath()
         {
-            string sdkPath = EditorPrefs.GetString("AndroidSdkRoot");
+            string sdkPath = AndroidExternalToolsSettings.sdkRootPath;
 
             if (string.IsNullOrEmpty(sdkPath) || EditorPrefs.GetBool("SdkUseEmbedded"))
             {


### PR DESCRIPTION
- [x] sign [contributor license agreement](https://code.facebook.com/cla/)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Replaced `EditorPrefs.GetString("AndroidSdkRoot")` with `AndroidExternalToolsSettings.sdkRootPath` as first doesn't always get updated after installing the new version of Unity Editor