### PR TITLE
Update ConsoleBase.cs (simplified)

### DIFF
--- a/UnitySDK/Assets/FacebookSDK/Examples/Mobile/Scripts/ConsoleBase.cs
+++ b/UnitySDK/Assets/FacebookSDK/Examples/Mobile/Scripts/ConsoleBase.cs
@@ -240,11 +240,7 @@ namespace Facebook.Unity.Example
         protected bool IsHorizontalLayout()
         {
             #if UNITY_IOS || UNITY_ANDROID
-                #if UNITY_2021 || UNITY_2022
-                    return Screen.orientation == ScreenOrientation.LandscapeLeft;
-                #else
-                    return Screen.orientation == ScreenOrientation.Landscape;
-                #endif
+                return Screen.orientation == ScreenOrientation.LandscapeLeft;
             #else
                 return true;
             #endif


### PR DESCRIPTION
Due to Unity API Document, we can find `ScreenOrientation.LandscapeLeft` is always there and equals to the deprecated `ScreenOrientation.Landscape`. (https://docs.unity3d.com/520/Documentation/ScriptReference/ScreenOrientation.LandscapeLeft.html) so `#if UNITY_2021 || UNITY_2022` could be removed!

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla/)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

## Test Plan

Test Plan: **Add your test plan here**
