### PR TITLE
fix: Prevent missing an assembly reference exception

### DIFF
--- a/UnitySDK/Assets/Editor/DisableBitcode.cs
+++ b/UnitySDK/Assets/Editor/DisableBitcode.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS && UNITY_EDITOR
 using System.IO;
 using UnityEngine;
 using UnityEditor;
@@ -35,3 +36,4 @@ namespace Facebook.Unity.PostProcess
          }
     }
 }
+#endif


### PR DESCRIPTION
Environment
Unity Editor Version: 2020.3.41f1
Unity SDK Version: 15.1.0
Build platform: Android

Pull Request Details
Prevent compilation error on android platform
Error log:
Assets\Editor\DisableBitcode.cs(6,19): error CS0234: The type or namespace name 'iOS' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)

Steps to Reproduce
Build Unity app on Android platform