### PR TITLE
`bug` Disregarding AndroidSdkRoot, if SdkUseEmbedded is enabled when building for Android.

### DIFF
--- a/Facebook.Unity.Editor/android/FacebookAndroidUtil.cs
+++ b/Facebook.Unity.Editor/android/FacebookAndroidUtil.cs
@@ -123,7 +123,7 @@ namespace Facebook.Unity.Editor
         {
             string sdkPath = EditorPrefs.GetString("AndroidSdkRoot");
 
-            if (string.IsNullOrEmpty(sdkPath) || EditorPrefs.GetBool("SdkUseEmbedded"))
+            if (EditorPrefs.GetBool("SdkUseEmbedded") || string.IsNullOrEmpty(sdkPath))
             {
                 try
                 {


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [X] sign [contributor license agreement](https://code.facebook.com/cla/)
- [X] I've ensured that all existing tests pass and added tests (when/where necessary)
- [X] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [X] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

In fresh Unity installations the `AndroidSdkRoot` editor pref is not set. They rather default to the tools installed with the editor (`SdkUseEmbedded` set to true).

Before the fix, we were unable to build unless a correct SDK path was explicitly set, even if the `SdkUseEmbedded` option was enabled. 

By checking the `SdkUseEmbedded` boolean first we can mitigate the problem.

The code can be further optimized by getting the set `AndroidSdkRoot` in an else statement, but I don't know if that's within the scope of this fix.

## Test Plan

Test Plan: **Add your test plan here**
1. Add a non Android SDK path as an Android SDK location in Editor's external tools.
2. Check "Android SDK Tools installed with Unity (recommended)"
3. Try to create a build.
4. The build will stop, failing to find the embedded Android SDK path since it checks for a null or an empty string first.