### PR TITLE
`bug` added missing Microsoft Xbox's build targets (using in 2020.3.x and higher)

### DIFF
--- a/Facebook.Unity.Settings/FacebookSettings.cs
+++ b/Facebook.Unity.Settings/FacebookSettings.cs
@@ -51,6 +51,9 @@ namespace Facebook.Unity.Settings
             CloudRendering,
             PS5,
             none,
+            GameCoreScarlett,
+            GameCoreXboxSeries,
+            GameCoreXboxOne,
         }
 
         private static List<OnChangeCallback> onChangeCallbacks = new List<OnChangeCallback>();


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [X] sign [contributor license agreement](https://code.facebook.com/cla/)
- [X] I've ensured that all existing tests pass and added tests (when/where necessary)
- [X] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [X] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Before changes: after entering in Play mode in Unity Editor, Facebook wrapper produce exception:
```
ArgumentException: Requested value 'GameCoreScarlett' was not found.
System.Enum+EnumResult.SetFailure (System.Enum+ParseFailureKind failure, System.String failureMessageID, System.Object failureMessageFormatArgument) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.Enum.TryParseEnum (System.Type enumType, System.String value, System.Boolean ignoreCase, System.Enum+EnumResult& parseResult) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.Enum.Parse (System.Type enumType, System.String value, System.Boolean ignoreCase) (at <695d1cc93cca45069c528c15c9fdd749>:0)
Facebook.Unity.Editor.PlayModeStateChanged.OnPlayModeStateChange (UnityEditor.PlayModeStateChange state) (at <d94eaa45a06f4a28b0b54293a88028d7>:0)
UnityEditor.EditorApplication.Internal_PlayModeStateChanged (UnityEditor.PlayModeStateChange state) (at <25578071f6e44201aac745680e5c8dfc>:0)

```
After changes: clear log

## Test Plan

Test Plan: nothing to test
