### PR TITLE
correct validation app id

### DIFF
--- a/Facebook.Unity.Settings/FacebookSettings.cs
+++ b/Facebook.Unity.Settings/FacebookSettings.cs
@@ -22,7 +22,8 @@ namespace Facebook.Unity.Settings
 {
     using System.Collections.Generic;
     using UnityEngine;
-
+    using System.Linq;
+    
     /// <summary>
     /// Facebook settings.
     /// </summary>
@@ -225,9 +226,10 @@ namespace Facebook.Unity.Settings
         {
             get
             {
-                return FacebookSettings.AppId != null
-                    && FacebookSettings.AppId.Length > 0
-                    && !FacebookSettings.AppId.Equals("0");
+                return !string.IsNullOrEmpty(FacebookSettings.AppId)
+                    && !FacebookSettings.AppId.Equals("0")
+                    && FacebookSettings.AppId.All(char.IsDigit)
+                    && !FacebookSettings.AppId.Contains(' ');
             }
         }
 


### PR DESCRIPTION
## Pull Request Details

fix when we are can use in app id any string, now we are can use only digit without spaces.

## Test Plan

App name - not correct
4543646345045303430 - correct
45945990 0 04 25 - not correct
13490adf0f423rfd - not correct
4590563464464646460 - correct
fdasfigerere042 - not correct
any my id 21312412443- not correct
