### PR TITLE
fix: update location of default UnityManifest.xml

### DIFF
--- a/Facebook.Unity.Editor/android/ManifestMod.cs
+++ b/Facebook.Unity.Editor/android/ManifestMod.cs
@@ -346,21 +346,24 @@ namespace Facebook.Unity.Editor
 
         private static void CreateDefaultAndroidManifest(string outputFile)
         {
-            var inputFile = Path.Combine(
-                EditorApplication.applicationContentsPath,
-                "PlaybackEngines/androidplayer/AndroidManifest.xml");
-            if (!File.Exists(inputFile))
+            string[] possiblePaths =
             {
-                // Unity moved this file. Try to get it at its new location
-                inputFile = Path.Combine(
-                    EditorApplication.applicationContentsPath,
-                    "PlaybackEngines/AndroidPlayer/Apk/AndroidManifest.xml");
-            }
+                // 2019.3+
+                "PlaybackEngines/AndroidPlayer/Apk/UnityManifest.xml"
+                // 2018.3 - 2019.2
+                "PlaybackEngines/AndroidPlayer/Apk/AndroidManifest.xml",
+                // 2017.2 - 2018.2
+                "PlaybackEngines/androidplayer/AndroidManifest.xml",
+            };
 
-            if (File.Exists(inputFile))
+            foreach (var relativePath in possiblePaths)
             {
-                File.Copy(inputFile, outputFile);
-                return;
+                var fullPath = Path.Combine(EditorApplication.applicationContentsPath, relativePath);
+                if (File.Exists(fullPath))
+                {
+                    File.Copy(fullPath, outputFile);
+                    return;
+                }
             }
 
             // On Unity 5.3+ we don't have default manifest so use our own


### PR DESCRIPTION
To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla/)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Unity renamed the default `AndroidManifest.xml` to `UnityManifest.xml` in `2019.3`. This hasn't been updated in this repo, what causes issues extra steps when trying to configure the Facebook SDK, specially in Unity-6 with the new GameActivity application entry.

<img width="496" alt="image" src="https://github.com/user-attachments/assets/f06a3f28-43cf-4981-b375-7e70d9456266" />

## Test Plan

Test Plan: 

1. [Enable GameActivity as ApplicationEntry](https://docs.unity3d.com/6000.2/Documentation/Manual/android-application-entries-set.html) in your Android PlayerSettings 
2. Add facebook sdk to your project
3. Click `Regenerate Android Manifest` on the `Facebook Settings`
4. See that the generated manifest inside `Plugins/Android` is based on the old facebook provided `DefaultAndroidManifest.xml`, instead of the one coming from Unity.
5.  Running the app will fail with error: MAIN + LAUNCHER not found in any activity of your AndroidManifest

After this PR, the issue does not happen.