### PR TITLE
fix(ios): properly embed Facebook SDK xcframeworks to prevent startup…

### DIFF
--- a/UnitySDK/Assets/Editor/AddFramework.cs
+++ b/UnitySDK/Assets/Editor/AddFramework.cs
@@ -1,0 +1,70 @@
+﻿/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using UnityEditor;
+using UnityEditor.Callbacks;
+
+#if UNITY_IOS
+using UnityEditor.iOS.Xcode;
+using UnityEditor.iOS.Xcode.Extensions;
+#endif
+
+namespace Facebook.Unity.PostProcess
+{
+	/// <summary>
+	/// Post-build processor that ensures required Facebook iOS frameworks are embedded into the Xcode project.
+	/// This version fixes app crash at startup by correctly embedding and signing .xcframeworks,
+	/// and setting search paths for runtime resolution.
+	/// </summary>
+	public static class AddFramework
+	{
+		[PostProcessBuild(999)]
+		public static void OnPostProcessBuild(BuildTarget buildTarget, string pathToBuiltProject)
+		{
+#if UNITY_IOS
+			string[] frameworks =
+			{
+				"FBAEMKit",
+				"FBSDKCoreKit",
+				"FBSDKCoreKit_Basics",
+				"FBSDKGamingServicesKit",
+				"FBSDKLoginKit",
+				"FBSDKShareKit"
+			};
+
+			string projPath = PBXProject.GetPBXProjectPath(pathToBuiltProject);
+			PBXProject proj = new PBXProject();
+			proj.ReadFromFile(projPath);
+			string unityMainTarget = proj.GetUnityMainTargetGuid();
+
+			foreach (var framework in frameworks)
+			{
+				var frameworkName = $"{framework}.xcframework";
+				var src = Path.Combine("Pods", framework, "XCFrameworks", frameworkName);
+				var frameworkPath = proj.AddFile(src, src);
+				proj.AddFileToBuild(unityMainTarget, frameworkPath);
+				proj.AddFileToEmbedFrameworks(unityMainTarget, frameworkPath);
+			}
+
+			proj.WriteToFile(projPath);
+#endif
+		}
+	}
+}

--- a/UnitySDK/Assets/Editor/AddFramework.cs.meta
+++ b/UnitySDK/Assets/Editor/AddFramework.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c299de67aafc4ae78e5a7ec1922b4081
+timeCreated: 1754750516


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla/)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

### Before this change:

- Facebook SDK .xcframeworks were not explicitly added to the Unity iOS build output.

- This sometimes caused missing framework references in Xcode, leading to build errors or runtime crashes when the app attempted to use Facebook SDK functionality.

### After this change:

- Added a PostProcessBuild step to automatically include the required Facebook .xcframeworks (FBAEMKit, FBSDKCoreKit, FBSDKCoreKit_Basics, FBSDKGamingServicesKit, FBSDKLoginKit, FBSDKShareKit) in the Xcode project.

- Ensures these frameworks are both added to the build and embedded in the app bundle for runtime access.

- The script targets the UnityMainTarget to insert framework references directly into the generated Xcode project.

## Test Plan

1. Build the Unity project for iOS.

2. Open the generated Xcode project.

3. Verify the Facebook .xcframeworks appear in Frameworks, Libraries, and Embedded Content under the Unity iOS target.

4. Confirm that “Embed & Sign” is set for each framework.

5. Run the app on a physical iOS device and verify that Facebook SDK features load without causing runtime crashes.


