### PR TITLE
enhancement: skip unnecessary work in FacebookImporter

### DIFF
--- a/Facebook.Unity.Editor/FacebookImporter.cs
+++ b/Facebook.Unity.Editor/FacebookImporter.cs
@@ -38,6 +38,8 @@ namespace Facebook.Unity.Editor
         {
             foreach (string str in importedAssets)
             {
+                if (!str.StartsWith("Assets/FacebookSDK/")) continue;
+                
                 currentAsset = str;
 
                 SetCanvasDllConfiguration("/Facebook.Unity.Canvas.dll");


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla/)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

Before:

FacebookImporter.OnPostprocessAllAssets() has a meaningful impact on every import operation, especially regarding allocations.

After:

It'll typically do next to no work, and be allocation-free.
 

Original commit comment: Change FacebookImporter to skip all non-FacebookSDK files via `path.StartsWith("Assets/FacebookSDK/")`. This saves a lot of needless string concatenations (2 per Set*Configuration call, or 2 x 32 per imported file).


## Test Plan

Probably not needed ;)
