### PR TITLE
Fix 'occured' -> 'occurred' typos in GraphResult / IResult docs

### DIFF
--- a/Facebook.Unity/Results/GraphResult.cs
+++ b/Facebook.Unity/Results/GraphResult.cs
@@ -33,7 +33,7 @@ namespace Facebook.Unity
             this.Init(this.RawResult);
 
             // The WWW object will throw an exception if accessing the texture field and
-            // an error has occured.
+            // an error has occurred.
             if (string.IsNullOrEmpty(result.webRequest.error))
             {
                 // The Graph API does not return textures directly, but a few endpoints can

--- a/Facebook.Unity/Results/IResult.cs
+++ b/Facebook.Unity/Results/IResult.cs
@@ -30,7 +30,7 @@ namespace Facebook.Unity
         /// <summary>
         /// Gets the error.
         /// </summary>
-        /// <value>The error string from the result. If no error occured value is null or empty.</value>
+        /// <value>The error string from the result. If no error occurred value is null or empty.</value>
         string Error { get; }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Facebook.Unity
         /// </summary>
         /// <value>
         /// The error string from the result, as a Dictionary.
-        /// If no error occured or cannot be parsed as a Dictionary, value is null.
+        /// If no error occurred or cannot be parsed as a Dictionary, value is null.
         /// </value>
         IDictionary<string, string> ErrorDictionary { get; }
 


### PR DESCRIPTION
Three internal comment/doc instances of `occured` in the Results folder:

- `Facebook.Unity/Results/GraphResult.cs:36` — inline comment (`an error has occured`)
- `Facebook.Unity/Results/IResult.cs:33` — `/// <value>` on `ErrorMessage`
- `Facebook.Unity/Results/IResult.cs:41` — `///` on `ResultDictionary`

Doc-only C# changes.