### PR TITLE
docs: fix typos in README, CHANGELOG, and code comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,10 +88,10 @@ The release has been deprecated due to Unity support issues caused by removing â
     - Subscriptions payments methods
 
 ### Fixed
-- Payments price convertion to double
+- Payments price conversion to double
 - Improved mobile orientation enum for Unity example
 - Improved mobile Tournaments example
-- Changed folder structure for External Dependecy Manager dlls
+- Changed folder structure for External Dependency Manager dlls
 
 ### Changed
 - Bumped SDK to 16.0.0

--- a/Facebook.Unity/FB.cs
+++ b/Facebook.Unity/FB.cs
@@ -62,12 +62,12 @@ namespace Facebook.Unity
 
         /// <summary>
         /// Gets or sets the graph API version.
-        /// The Unity sdk is by default pegged to the lastest version of the graph api
+        /// The Unity sdk is by default pegged to the latest version of the graph api
         /// at the time of the SDKs release. To override this value to use a different
         /// version set this value.
         /// <remarks>
         /// This value is only valid for direct api calls made through FB.Api and the
-        /// graph api version used by the javscript sdk when running on the web. The
+        /// graph api version used by the JavaScript SDK when running on the web. The
         /// underlyting Android and iOS SDKs will still be pegged to the graph api
         /// version of this release.
         /// </remarks>

--- a/README.mdown
+++ b/README.mdown
@@ -39,7 +39,7 @@ We are able to accept contributions to the Facebook SDK for Unity. To contribute
 - Follow the instructions in the [CONTRIBUTING.mdown](https://github.com/facebook/facebook-sdk-for-unity/blob/master/CONTRIBUTING.mdown).
 - Submit your pull request to the [dev](https://github.com/facebook/facebook-sdk-for-unity/tree/dev) branch. This allows us to merge your change into our internal master and then push out the change in the next release.
 
-SETUP DEVELOPMENT ENVIRONTMENT IN MAC
+SETUP DEVELOPMENT ENVIRONMENT IN MAC
 -------------
 Since Unity decided to change the way in which each of the versions was installed in the Mac file system, Unity Hub, and also due to changes in the distribution of implementations in the DLL from version 2019, it is necessary to solve the dependencies references in the project depending on the installed version.
 -For this, this process has been automated through a script ./configure.sh that is in the root of the project. You should run this script before opening the Facebook.sln project.


### PR DESCRIPTION
Six spelling fixes across three files:

- `README.mdown`: `ENVIRONTMENT` → `ENVIRONMENT`
- `CHANGELOG.md`: `convertion` → `conversion`, `Dependecy` → `Dependency`
- `Facebook.Unity/FB.cs`: `lastest` → `latest`, `javscript` → `JavaScript`, `underlyting` → `underlying`